### PR TITLE
Modularised and extend critique.py

### DIFF
--- a/critique.md
+++ b/critique.md
@@ -1,273 +1,70 @@
 # Critique of *exampledata* files
 
-* date: 2020-01-22 12:01:28.732098
+* date: 2020-10-22 16:49:19.487790
 * h5py version: 2.10.0
-
-## path: .
-
-| file              | critique      |
-| ----------------- | ------------- |
-| ``.gitignore``    | not HDF5 file |
-| ``.project``      | not HDF5 file |
-| ``.pydevproject`` | not HDF5 file |
-| ``MANIFEST.in``   | not HDF5 file |
-| ``README.rst``    | not HDF5 file |
-| ``critique.md``   | not HDF5 file |
-| ``critique.py``   | not HDF5 file |
-
-
-## path: ./ANSTO/hdf4
-
-| file                  | critique                             |
-| --------------------- | ------------------------------------ |
-| ``PLP0006018.nx.hdf`` | NeXus HDF5 file, 1 **NXentry** group |
-
-
-## path: ./APS/CCDImageServer
-
-| file           | critique      |
-| -------------- | ------------- |
-| ``README.txt`` | not HDF5 file |
-
-
-## path: ./APS/CCDImageServer/hdf4
-
-| file                            | critique      |
-| ------------------------------- | ------------- |
-| ``Smither400.3_apr0300051.hdf`` | not HDF5 file |
-| ``Smither400.3_apr0300052.hdf`` | not HDF5 file |
-| ``Smither400.3_apr0300053.hdf`` | not HDF5 file |
-| ``Smither400.3_apr0300054.hdf`` | not HDF5 file |
-| ``Smither400.3_apr0300055.hdf`` | not HDF5 file |
-| ``recon_0123.hdf``              | not HDF5 file |
-| ``recon_0124.hdf``              | not HDF5 file |
-| ``recon_0125.hdf``              | not HDF5 file |
-
-
-## path: ./APS/EPICSareaDetector/hdf5
-
-| file                    | critique                             |
-| ----------------------- | ------------------------------------ |
-| ``AgBehenate_228.hdf5`` | NeXus HDF5 file, 1 **NXentry** group |
-
-
-## path: ./APS/NXsas
-
-| file                     | critique      |
-| ------------------------ | ------------- |
-| ``create_nexus_data.py`` | not HDF5 file |
-| ``xture.txt``            | not HDF5 file |
-
-
-## path: ./APS/NXsas/hdf5
-
-| file                   | critique                             |
-| ---------------------- | ------------------------------------ |
-| ``nexus-example.hdf5`` | NeXus HDF5 file, 1 **NXentry** group |
-
-
-## path: ./APS/other/hdf5
-
-| file                     | critique                             |
-| ------------------------ | ------------------------------------ |
-| ``ID34_not_complete.h5`` | NeXus HDF5 file, 1 **NXentry** group |
-
-
-## path: ./APS/scan2nexus
-
-| file                | critique      |
-| ------------------- | ------------- |
-| ``14BMC_0015.mda``  | not HDF5 file |
-| ``2iddf_0106.mda``  | not HDF5 file |
-| ``README``          | not HDF5 file |
-| ``mts_0347.mda``    | not HDF5 file |
-| ``mts_0348.mda``    | not HDF5 file |
-| ``sample.mda.text`` | not HDF5 file |
-| ``sample1.mda``     | not HDF5 file |
-
-
-## path: ./APS/scan2nexus/hdf4
-
-| file                 | critique      |
-| -------------------- | ------------- |
-| ``14BMC_0015.nexus`` | not HDF5 file |
-| ``2iddf_0106.nexus`` | not HDF5 file |
-| ``mts_0347.nexus``   | not HDF5 file |
-| ``mts_0348.nexus``   | not HDF5 file |
-| ``sample1.nexus``    | not HDF5 file |
-
-
-## path: ./APS/scan2nexus/xml
-
-| file               | critique      |
-| ------------------ | ------------- |
-| ``14BMC_0015.xml`` | not HDF5 file |
-| ``2iddf_0106.xml`` | not HDF5 file |
-| ``mts_0347.xml``   | not HDF5 file |
-| ``mts_0348.xml``   | not HDF5 file |
-| ``sample1.xml``    | not HDF5 file |
-
-
-## path: ./APS/tomo/hdf4
-
-| file                        | critique      |
-| --------------------------- | ------------- |
-| ``Tomography_metadata.hdf`` | not HDF5 file |
-| ``Tomography_raw.hdf``      | not HDF5 file |
-
-
-## path: ./DLS
-
-| file           | critique      |
-| -------------- | ------------- |
-| ``README.rst`` | not HDF5 file |
-
-
-## path: ./DLS/NXquadric/hdf5
-
-| file                     | critique                             |
-| ------------------------ | ------------------------------------ |
-| ``sample_capillary.nxs`` | NeXus HDF5 file, 1 **NXentry** group |
-
-
-## path: ./DLS/i03_i04_NXmx
-
-| file           | critique      |
-| -------------- | ------------- |
-| ``README.txt`` | not HDF5 file |
-
-
-## path: ./DLS/i03_i04_NXmx/hdf5
-
-| file              | critique                             |
-| ----------------- | ------------------------------------ |
-| ``Therm_6_2.nxs`` | NeXus HDF5 file, 1 **NXentry** group |
-
-
-## path: ./DLS/i16/hdf5
-
-| file           | critique                             |
-| -------------- | ------------------------------------ |
-| ``538039.nxs`` | NeXus HDF5 file, 1 **NXentry** group |
-
-
-## path: ./DLS/i16/hdf5/538039-pilatus100k-files
-
-| file           | critique                             |
-| -------------- | ------------------------------------ |
-| ``538039.hdf`` | NeXus HDF5 file, 1 **NXentry** group |
-
-
-## path: ./DLS/p45/hdf5
-
-| file                  | critique                             |
-| --------------------- | ------------------------------------ |
-| ``p45-1168-mic.hdf5`` | NeXus HDF5 file, 1 **NXentry** group |
-| ``p45-1168.nxs``      | NeXus HDF5 file, 1 **NXentry** group |
-| ``p45-2194.nxs``      | NeXus HDF5 file, 1 **NXentry** group |
-| ``p45-316.nxs``       | NeXus HDF5 file, 1 **NXentry** group |
-
-
-## path: ./DLS/reflections/hdf5
-
-| file                         | critique                             |
-| ---------------------------- | ------------------------------------ |
-| ``thaumatin_integrated.nxs`` | NeXus HDF5 file, 1 **NXentry** group |
-
-
-## path: ./IPNS/LRMECS/hdf4
-
-| file             | critique      |
-| ---------------- | ------------- |
-| ``lrcs3701.nxs`` | not HDF5 file |
-
-
-## path: ./IPNS/LRMECS/hdf5
-
-| file             | critique                              |
-| ---------------- | ------------------------------------- |
-| ``lrcs3701.nx5`` | NeXus HDF5 file, 2 **NXentry** groups |
-
-
-## path: ./Soleil/hdf5
-
-| file           | critique                             |
-| -------------- | ------------------------------------ |
-| ``file_1.nxs`` | NeXus HDF5 file, 1 **NXentry** group |
-| ``file_2.nxs`` | NeXus HDF5 file, 1 **NXentry** group |
-
-
-## path: ./SwissFEL
-
-| file       | critique      |
-| ---------- | ------------- |
-| ``README`` | not HDF5 file |
-
-
-## path: ./SwissFEL/hdf5
-
-| file                                   | critique                             |
-| -------------------------------------- | ------------------------------------ |
-| ``lyso009a_0087.JF07T32V01_master.h5`` | NeXus HDF5 file, 1 **NXentry** group |
-
-
-## path: ./code/hdf4
-
-| file           | critique      |
-| -------------- | ------------- |
-| ``NXtest.hdf`` | not HDF5 file |
-| ``dmc01.hdf``  | not HDF5 file |
-| ``dmc02.hdf``  | not HDF5 file |
-
-
-## path: ./code/hdf5
-
-| file                     | critique                              |
-| ------------------------ | ------------------------------------- |
-| ``NXtest.h5``            | NeXus HDF5 file, 2 **NXentry** groups |
-| ``dmc01.h5``             | NeXus HDF5 file, 1 **NXentry** group  |
-| ``dmc02.h5``             | NeXus HDF5 file, 1 **NXentry** group  |
-| ``focus2007n001335.hdf`` | NeXus HDF5 file, 1 **NXentry** group  |
-| ``sans2009n012333.hdf``  | NeXus HDF5 file, 1 **NXentry** group  |
-
-
-## path: ./code/xml
-
-| file               | critique      |
-| ------------------ | ------------- |
-| ``NXtest.xml.txt`` | not HDF5 file |
-| ``dmc01.xml.txt``  | not HDF5 file |
-| ``dmc02.xml.txt``  | not HDF5 file |
-
-
-## path: ./hdf5
-
-| file                        | critique                             |
-| --------------------------- | ------------------------------------ |
-| ``simple3D.h5``             | NeXus HDF5 file, 1 **NXentry** group |
-| ``writer_1_3.h5``           | NeXus HDF5 file, 1 **NXentry** group |
-| ``writer_1_3__niac2014.h5`` | NeXus HDF5 file, 1 **NXentry** group |
-
-
-## path: ./nxpdb
-
-| file            | critique      |
-| --------------- | ------------- |
-| ``4n8z.cif``    | not HDF5 file |
-| ``4n8z.h5.cif`` | not HDF5 file |
-| ``README.rst``  | not HDF5 file |
-
-
-## path: ./nxpdb/hdf5
-
-| file        | critique                             |
-| ----------- | ------------------------------------ |
-| ``4n8z.h5`` | NeXus HDF5 file, 1 **NXentry** group |
-
-
-## path: ./xml
-
-| file               | critique      |
-| ------------------ | ------------- |
-| ``verysimple.xml`` | not HDF5 file |
+* unimplemented test cases are marked in the table with an asterisk
+| path                                        | file                                     | File Type    | NXentry Count | Application Def's |
+| ------------------------------------------- | ---------------------------------------- | ------------ | ------------- | ----------------- |
+| ``./ANSTO/hdf4``                            | ``PLP0006018.nx.hdf``                    | HDF5         | 1             | None found        |
+| ``./APS/CCDImageServer/hdf4``               | ``Smither400.3_apr0300051.hdf``          | HDF4         | *             | *                 |
+| ``./APS/CCDImageServer/hdf4``               | ``Smither400.3_apr0300052.hdf``          | HDF4         | *             | *                 |
+| ``./APS/CCDImageServer/hdf4``               | ``Smither400.3_apr0300053.hdf``          | HDF4         | *             | *                 |
+| ``./APS/CCDImageServer/hdf4``               | ``Smither400.3_apr0300054.hdf``          | HDF4         | *             | *                 |
+| ``./APS/CCDImageServer/hdf4``               | ``Smither400.3_apr0300055.hdf``          | HDF4         | *             | *                 |
+| ``./APS/CCDImageServer/hdf4``               | ``recon_0123.hdf``                       | HDF4         | *             | *                 |
+| ``./APS/CCDImageServer/hdf4``               | ``recon_0124.hdf``                       | HDF4         | *             | *                 |
+| ``./APS/CCDImageServer/hdf4``               | ``recon_0125.hdf``                       | HDF4         | *             | *                 |
+| ``./APS/EPICSareaDetector/hdf5``            | ``AgBehenate_228.hdf5``                  | HDF5         | 1             | NXsas             |
+| ``./APS/NXsas/hdf5``                        | ``nexus-example.hdf5``                   | HDF5         | 1             | NXsas             |
+| ``./APS/other/hdf5``                        | ``ID34_not_complete.h5``                 | HDF5         | 1             | None found        |
+| ``./APS/scan2nexus``                        | ``14BMC_0015.mda``                       | unrecognised | -             | -                 |
+| ``./APS/scan2nexus``                        | ``2iddf_0106.mda``                       | unrecognised | -             | -                 |
+| ``./APS/scan2nexus``                        | ``README``                               | unrecognised | -             | -                 |
+| ``./APS/scan2nexus``                        | ``mts_0347.mda``                         | unrecognised | -             | -                 |
+| ``./APS/scan2nexus``                        | ``mts_0348.mda``                         | unrecognised | -             | -                 |
+| ``./APS/scan2nexus``                        | ``sample.mda.text``                      | unrecognised | -             | -                 |
+| ``./APS/scan2nexus``                        | ``sample1.mda``                          | unrecognised | -             | -                 |
+| ``./APS/scan2nexus/hdf4``                   | ``14BMC_0015.nexus``                     | HDF4         | *             | *                 |
+| ``./APS/scan2nexus/hdf4``                   | ``2iddf_0106.nexus``                     | unrecognised | -             | -                 |
+| ``./APS/scan2nexus/hdf4``                   | ``mts_0347.nexus``                       | HDF4         | *             | *                 |
+| ``./APS/scan2nexus/hdf4``                   | ``mts_0348.nexus``                       | HDF4         | *             | *                 |
+| ``./APS/scan2nexus/hdf4``                   | ``sample1.nexus``                        | HDF4         | *             | *                 |
+| ``./APS/scan2nexus/xml``                    | ``14BMC_0015.xml``                       | XML          | *             | *                 |
+| ``./APS/scan2nexus/xml``                    | ``2iddf_0106.xml``                       | XML          | *             | *                 |
+| ``./APS/scan2nexus/xml``                    | ``mts_0347.xml``                         | XML          | *             | *                 |
+| ``./APS/scan2nexus/xml``                    | ``mts_0348.xml``                         | XML          | *             | *                 |
+| ``./APS/scan2nexus/xml``                    | ``sample1.xml``                          | XML          | *             | *                 |
+| ``./APS/tomo/hdf4``                         | ``Tomography_metadata.hdf``              | HDF4         | *             | *                 |
+| ``./APS/tomo/hdf4``                         | ``Tomography_raw.hdf``                   | HDF4         | *             | *                 |
+| ``./DLS/NXquadric/hdf5``                    | ``sample_capillary.nxs``                 | HDF5         | 1             | None found        |
+| ``./DLS/i03_i04_NXmx/hdf5``                 | ``Therm_6_2.nxs``                        | HDF5         | 1             | error             |
+| ``./DLS/i16/hdf5``                          | ``538039.nxs``                           | HDF5         | 1             | NXmx              |
+| ``./DLS/i16/hdf5/538039-pilatus100k-files`` | ``538039.hdf``                           | HDF5         | 1             | None found        |
+| ``./DLS/p45/hdf5``                          | ``p45-1168-mic.hdf5``                    | HDF5         | 1             | None found        |
+| ``./DLS/p45/hdf5``                          | ``p45-1168.nxs``                         | HDF5         | 1             | None found        |
+| ``./DLS/p45/hdf5``                          | ``p45-2194.nxs``                         | HDF5         | 1             | None found        |
+| ``./DLS/p45/hdf5``                          | ``p45-316.nxs``                          | HDF5         | 1             | None found        |
+| ``./DLS/reflections/hdf5``                  | ``thaumatin_integrated.nxs``             | HDF5         | 1             | error             |
+| ``./DLS/reflections/hdf5``                  | ``thaumatin_integrated_multisample.nxs`` | HDF5         | 1             | error             |
+| ``./IPNS/LRMECS/hdf4``                      | ``lrcs3701.nxs``                         | unrecognised | -             | -                 |
+| ``./IPNS/LRMECS/hdf5``                      | ``lrcs3701.nx5``                         | HDF5         | 2             | None found        |
+| ``./Soleil/hdf5``                           | ``file_1.nxs``                           | HDF5         | 1             | NXentry           |
+| ``./Soleil/hdf5``                           | ``file_2.nxs``                           | HDF5         | 1             | NXentry           |
+| ``./SwissFEL``                              | ``README``                               | unrecognised | -             | -                 |
+| ``./SwissFEL/hdf5``                         | ``lyso009a_0087.JF07T32V01_master.h5``   | HDF5         | 1             | error             |
+| ``./code/hdf4``                             | ``NXtest.hdf``                           | HDF4         | *             | *                 |
+| ``./code/hdf4``                             | ``dmc01.hdf``                            | HDF4         | *             | *                 |
+| ``./code/hdf4``                             | ``dmc02.hdf``                            | HDF4         | *             | *                 |
+| ``./code/hdf5``                             | ``NXtest.h5``                            | HDF5         | 2             | None found        |
+| ``./code/hdf5``                             | ``dmc01.h5``                             | HDF5         | 1             | None found        |
+| ``./code/hdf5``                             | ``dmc02.h5``                             | HDF5         | 1             | None found        |
+| ``./code/hdf5``                             | ``focus2007n001335.hdf``                 | HDF5         | 1             | None found        |
+| ``./code/hdf5``                             | ``sans2009n012333.hdf``                  | HDF5         | 1             | None found        |
+| ``./hdf5``                                  | ``simple3D.h5``                          | HDF5         | 1             | None found        |
+| ``./hdf5``                                  | ``writer_1_3.h5``                        | HDF5         | 1             | None found        |
+| ``./hdf5``                                  | ``writer_1_3__niac2014.h5``              | HDF5         | 1             | None found        |
+| ``./nxpdb``                                 | ``4n8z.cif``                             | unrecognised | -             | -                 |
+| ``./nxpdb``                                 | ``4n8z.h5.cif``                          | unrecognised | -             | -                 |
+| ``./nxpdb/hdf5``                            | ``4n8z.h5``                              | HDF5         | 1             | None found        |
+| ``./xml``                                   | ``verysimple.xml``                       | XML          | *             | *                 |
 

--- a/critique.md
+++ b/critique.md
@@ -1,7 +1,7 @@
 # Critique of *exampledata* files
 
-* date: 2020-11-10 17:41:04.990698
-* h5py version: 2.7.1
+* date: 2020-11-10 18:03:43.112348
+* h5py version: 2.10.0
 * unimplemented test cases are marked in the table with an asterisk
 
 | path                                      | file                                   | File Type    | NXentry Count | Application Def's |
@@ -15,8 +15,8 @@
 | `./APS/CCDImageServer/hdf4`               | `recon_0123.hdf`                       | HDF4         | *             | *                 |
 | `./APS/CCDImageServer/hdf4`               | `recon_0124.hdf`                       | HDF4         | *             | *                 |
 | `./APS/CCDImageServer/hdf4`               | `recon_0125.hdf`                       | HDF4         | *             | *                 |
-| `./APS/EPICSareaDetector/hdf5`            | `AgBehenate_228.hdf5`                  | HDF5         | 1             | error             |
-| `./APS/NXsas/hdf5`                        | `nexus-example.hdf5`                   | HDF5         | 1             | error             |
+| `./APS/EPICSareaDetector/hdf5`            | `AgBehenate_228.hdf5`                  | HDF5         | 1             | NXsas             |
+| `./APS/NXsas/hdf5`                        | `nexus-example.hdf5`                   | HDF5         | 1             | NXsas             |
 | `./APS/other/hdf5`                        | `ID34_not_complete.h5`                 | HDF5         | 1             | None found        |
 | `./APS/scan2nexus`                        | `14BMC_0015.mda`                       | unrecognised | -             | -                 |
 | `./APS/scan2nexus`                        | `2iddf_0106.mda`                       | unrecognised | -             | -                 |
@@ -39,7 +39,7 @@
 | `./APS/tomo/hdf4`                         | `Tomography_raw.hdf`                   | HDF4         | *             | *                 |
 | `./DLS/NXquadric/hdf5`                    | `sample_capillary.nxs`                 | HDF5         | 1             | None found        |
 | `./DLS/i03_i04_NXmx/hdf5`                 | `Therm_6_2.nxs`                        | HDF5         | 1             | error             |
-| `./DLS/i16/hdf5`                          | `538039.nxs`                           | HDF5         | not NeXus     | -                 |
+| `./DLS/i16/hdf5`                          | `538039.nxs`                           | HDF5         | 1             | NXmx              |
 | `./DLS/i16/hdf5/538039-pilatus100k-files` | `538039.hdf`                           | HDF5         | 1             | None found        |
 | `./DLS/p45/hdf5`                          | `p45-1168-mic.hdf5`                    | HDF5         | 1             | None found        |
 | `./DLS/p45/hdf5`                          | `p45-1168.nxs`                         | HDF5         | 1             | None found        |
@@ -49,8 +49,8 @@
 | `./DLS/reflections/hdf5`                  | `thaumatin_integrated_multisample.nxs` | HDF5         | 1             | error             |
 | `./IPNS/LRMECS/hdf4`                      | `lrcs3701.nxs`                         | unrecognised | -             | -                 |
 | `./IPNS/LRMECS/hdf5`                      | `lrcs3701.nx5`                         | HDF5         | 2             | None found        |
-| `./Soleil/hdf5`                           | `file_1.nxs`                           | HDF5         | 1             | error             |
-| `./Soleil/hdf5`                           | `file_2.nxs`                           | HDF5         | 1             | error             |
+| `./Soleil/hdf5`                           | `file_1.nxs`                           | HDF5         | 1             | NXentry           |
+| `./Soleil/hdf5`                           | `file_2.nxs`                           | HDF5         | 1             | NXentry           |
 | `./SwissFEL`                              | `README`                               | unrecognised | -             | -                 |
 | `./SwissFEL/hdf5`                         | `lyso009a_0087.JF07T32V01_master.h5`   | HDF5         | 1             | error             |
 | `./code/hdf4`                             | `NXtest.hdf`                           | HDF4         | *             | *                 |

--- a/critique.md
+++ b/critique.md
@@ -1,6 +1,6 @@
 # Critique of *exampledata* files
 
-* date: 2020-11-10 18:03:43.112348
+* date: 2020-11-10 18:28:34.654081
 * h5py version: 2.10.0
 * unimplemented test cases are marked in the table with an asterisk
 

--- a/critique.md
+++ b/critique.md
@@ -1,70 +1,71 @@
 # Critique of *exampledata* files
 
-* date: 2020-10-22 16:49:19.487790
-* h5py version: 2.10.0
+* date: 2020-11-10 17:41:04.990698
+* h5py version: 2.7.1
 * unimplemented test cases are marked in the table with an asterisk
-| path                                        | file                                     | File Type    | NXentry Count | Application Def's |
-| ------------------------------------------- | ---------------------------------------- | ------------ | ------------- | ----------------- |
-| ``./ANSTO/hdf4``                            | ``PLP0006018.nx.hdf``                    | HDF5         | 1             | None found        |
-| ``./APS/CCDImageServer/hdf4``               | ``Smither400.3_apr0300051.hdf``          | HDF4         | *             | *                 |
-| ``./APS/CCDImageServer/hdf4``               | ``Smither400.3_apr0300052.hdf``          | HDF4         | *             | *                 |
-| ``./APS/CCDImageServer/hdf4``               | ``Smither400.3_apr0300053.hdf``          | HDF4         | *             | *                 |
-| ``./APS/CCDImageServer/hdf4``               | ``Smither400.3_apr0300054.hdf``          | HDF4         | *             | *                 |
-| ``./APS/CCDImageServer/hdf4``               | ``Smither400.3_apr0300055.hdf``          | HDF4         | *             | *                 |
-| ``./APS/CCDImageServer/hdf4``               | ``recon_0123.hdf``                       | HDF4         | *             | *                 |
-| ``./APS/CCDImageServer/hdf4``               | ``recon_0124.hdf``                       | HDF4         | *             | *                 |
-| ``./APS/CCDImageServer/hdf4``               | ``recon_0125.hdf``                       | HDF4         | *             | *                 |
-| ``./APS/EPICSareaDetector/hdf5``            | ``AgBehenate_228.hdf5``                  | HDF5         | 1             | NXsas             |
-| ``./APS/NXsas/hdf5``                        | ``nexus-example.hdf5``                   | HDF5         | 1             | NXsas             |
-| ``./APS/other/hdf5``                        | ``ID34_not_complete.h5``                 | HDF5         | 1             | None found        |
-| ``./APS/scan2nexus``                        | ``14BMC_0015.mda``                       | unrecognised | -             | -                 |
-| ``./APS/scan2nexus``                        | ``2iddf_0106.mda``                       | unrecognised | -             | -                 |
-| ``./APS/scan2nexus``                        | ``README``                               | unrecognised | -             | -                 |
-| ``./APS/scan2nexus``                        | ``mts_0347.mda``                         | unrecognised | -             | -                 |
-| ``./APS/scan2nexus``                        | ``mts_0348.mda``                         | unrecognised | -             | -                 |
-| ``./APS/scan2nexus``                        | ``sample.mda.text``                      | unrecognised | -             | -                 |
-| ``./APS/scan2nexus``                        | ``sample1.mda``                          | unrecognised | -             | -                 |
-| ``./APS/scan2nexus/hdf4``                   | ``14BMC_0015.nexus``                     | HDF4         | *             | *                 |
-| ``./APS/scan2nexus/hdf4``                   | ``2iddf_0106.nexus``                     | unrecognised | -             | -                 |
-| ``./APS/scan2nexus/hdf4``                   | ``mts_0347.nexus``                       | HDF4         | *             | *                 |
-| ``./APS/scan2nexus/hdf4``                   | ``mts_0348.nexus``                       | HDF4         | *             | *                 |
-| ``./APS/scan2nexus/hdf4``                   | ``sample1.nexus``                        | HDF4         | *             | *                 |
-| ``./APS/scan2nexus/xml``                    | ``14BMC_0015.xml``                       | XML          | *             | *                 |
-| ``./APS/scan2nexus/xml``                    | ``2iddf_0106.xml``                       | XML          | *             | *                 |
-| ``./APS/scan2nexus/xml``                    | ``mts_0347.xml``                         | XML          | *             | *                 |
-| ``./APS/scan2nexus/xml``                    | ``mts_0348.xml``                         | XML          | *             | *                 |
-| ``./APS/scan2nexus/xml``                    | ``sample1.xml``                          | XML          | *             | *                 |
-| ``./APS/tomo/hdf4``                         | ``Tomography_metadata.hdf``              | HDF4         | *             | *                 |
-| ``./APS/tomo/hdf4``                         | ``Tomography_raw.hdf``                   | HDF4         | *             | *                 |
-| ``./DLS/NXquadric/hdf5``                    | ``sample_capillary.nxs``                 | HDF5         | 1             | None found        |
-| ``./DLS/i03_i04_NXmx/hdf5``                 | ``Therm_6_2.nxs``                        | HDF5         | 1             | error             |
-| ``./DLS/i16/hdf5``                          | ``538039.nxs``                           | HDF5         | 1             | NXmx              |
-| ``./DLS/i16/hdf5/538039-pilatus100k-files`` | ``538039.hdf``                           | HDF5         | 1             | None found        |
-| ``./DLS/p45/hdf5``                          | ``p45-1168-mic.hdf5``                    | HDF5         | 1             | None found        |
-| ``./DLS/p45/hdf5``                          | ``p45-1168.nxs``                         | HDF5         | 1             | None found        |
-| ``./DLS/p45/hdf5``                          | ``p45-2194.nxs``                         | HDF5         | 1             | None found        |
-| ``./DLS/p45/hdf5``                          | ``p45-316.nxs``                          | HDF5         | 1             | None found        |
-| ``./DLS/reflections/hdf5``                  | ``thaumatin_integrated.nxs``             | HDF5         | 1             | error             |
-| ``./DLS/reflections/hdf5``                  | ``thaumatin_integrated_multisample.nxs`` | HDF5         | 1             | error             |
-| ``./IPNS/LRMECS/hdf4``                      | ``lrcs3701.nxs``                         | unrecognised | -             | -                 |
-| ``./IPNS/LRMECS/hdf5``                      | ``lrcs3701.nx5``                         | HDF5         | 2             | None found        |
-| ``./Soleil/hdf5``                           | ``file_1.nxs``                           | HDF5         | 1             | NXentry           |
-| ``./Soleil/hdf5``                           | ``file_2.nxs``                           | HDF5         | 1             | NXentry           |
-| ``./SwissFEL``                              | ``README``                               | unrecognised | -             | -                 |
-| ``./SwissFEL/hdf5``                         | ``lyso009a_0087.JF07T32V01_master.h5``   | HDF5         | 1             | error             |
-| ``./code/hdf4``                             | ``NXtest.hdf``                           | HDF4         | *             | *                 |
-| ``./code/hdf4``                             | ``dmc01.hdf``                            | HDF4         | *             | *                 |
-| ``./code/hdf4``                             | ``dmc02.hdf``                            | HDF4         | *             | *                 |
-| ``./code/hdf5``                             | ``NXtest.h5``                            | HDF5         | 2             | None found        |
-| ``./code/hdf5``                             | ``dmc01.h5``                             | HDF5         | 1             | None found        |
-| ``./code/hdf5``                             | ``dmc02.h5``                             | HDF5         | 1             | None found        |
-| ``./code/hdf5``                             | ``focus2007n001335.hdf``                 | HDF5         | 1             | None found        |
-| ``./code/hdf5``                             | ``sans2009n012333.hdf``                  | HDF5         | 1             | None found        |
-| ``./hdf5``                                  | ``simple3D.h5``                          | HDF5         | 1             | None found        |
-| ``./hdf5``                                  | ``writer_1_3.h5``                        | HDF5         | 1             | None found        |
-| ``./hdf5``                                  | ``writer_1_3__niac2014.h5``              | HDF5         | 1             | None found        |
-| ``./nxpdb``                                 | ``4n8z.cif``                             | unrecognised | -             | -                 |
-| ``./nxpdb``                                 | ``4n8z.h5.cif``                          | unrecognised | -             | -                 |
-| ``./nxpdb/hdf5``                            | ``4n8z.h5``                              | HDF5         | 1             | None found        |
-| ``./xml``                                   | ``verysimple.xml``                       | XML          | *             | *                 |
+
+| path                                      | file                                   | File Type    | NXentry Count | Application Def's |
+| ----------------------------------------- | -------------------------------------- | ------------ | ------------- | ----------------- |
+| `./ANSTO/hdf4`                            | `PLP0006018.nx.hdf`                    | HDF5         | 1             | None found        |
+| `./APS/CCDImageServer/hdf4`               | `Smither400.3_apr0300051.hdf`          | HDF4         | *             | *                 |
+| `./APS/CCDImageServer/hdf4`               | `Smither400.3_apr0300052.hdf`          | HDF4         | *             | *                 |
+| `./APS/CCDImageServer/hdf4`               | `Smither400.3_apr0300053.hdf`          | HDF4         | *             | *                 |
+| `./APS/CCDImageServer/hdf4`               | `Smither400.3_apr0300054.hdf`          | HDF4         | *             | *                 |
+| `./APS/CCDImageServer/hdf4`               | `Smither400.3_apr0300055.hdf`          | HDF4         | *             | *                 |
+| `./APS/CCDImageServer/hdf4`               | `recon_0123.hdf`                       | HDF4         | *             | *                 |
+| `./APS/CCDImageServer/hdf4`               | `recon_0124.hdf`                       | HDF4         | *             | *                 |
+| `./APS/CCDImageServer/hdf4`               | `recon_0125.hdf`                       | HDF4         | *             | *                 |
+| `./APS/EPICSareaDetector/hdf5`            | `AgBehenate_228.hdf5`                  | HDF5         | 1             | error             |
+| `./APS/NXsas/hdf5`                        | `nexus-example.hdf5`                   | HDF5         | 1             | error             |
+| `./APS/other/hdf5`                        | `ID34_not_complete.h5`                 | HDF5         | 1             | None found        |
+| `./APS/scan2nexus`                        | `14BMC_0015.mda`                       | unrecognised | -             | -                 |
+| `./APS/scan2nexus`                        | `2iddf_0106.mda`                       | unrecognised | -             | -                 |
+| `./APS/scan2nexus`                        | `README`                               | unrecognised | -             | -                 |
+| `./APS/scan2nexus`                        | `mts_0347.mda`                         | unrecognised | -             | -                 |
+| `./APS/scan2nexus`                        | `mts_0348.mda`                         | unrecognised | -             | -                 |
+| `./APS/scan2nexus`                        | `sample.mda.text`                      | unrecognised | -             | -                 |
+| `./APS/scan2nexus`                        | `sample1.mda`                          | unrecognised | -             | -                 |
+| `./APS/scan2nexus/hdf4`                   | `14BMC_0015.nexus`                     | HDF4         | *             | *                 |
+| `./APS/scan2nexus/hdf4`                   | `2iddf_0106.nexus`                     | unrecognised | -             | -                 |
+| `./APS/scan2nexus/hdf4`                   | `mts_0347.nexus`                       | HDF4         | *             | *                 |
+| `./APS/scan2nexus/hdf4`                   | `mts_0348.nexus`                       | HDF4         | *             | *                 |
+| `./APS/scan2nexus/hdf4`                   | `sample1.nexus`                        | HDF4         | *             | *                 |
+| `./APS/scan2nexus/xml`                    | `14BMC_0015.xml`                       | XML          | *             | *                 |
+| `./APS/scan2nexus/xml`                    | `2iddf_0106.xml`                       | XML          | *             | *                 |
+| `./APS/scan2nexus/xml`                    | `mts_0347.xml`                         | XML          | *             | *                 |
+| `./APS/scan2nexus/xml`                    | `mts_0348.xml`                         | XML          | *             | *                 |
+| `./APS/scan2nexus/xml`                    | `sample1.xml`                          | XML          | *             | *                 |
+| `./APS/tomo/hdf4`                         | `Tomography_metadata.hdf`              | HDF4         | *             | *                 |
+| `./APS/tomo/hdf4`                         | `Tomography_raw.hdf`                   | HDF4         | *             | *                 |
+| `./DLS/NXquadric/hdf5`                    | `sample_capillary.nxs`                 | HDF5         | 1             | None found        |
+| `./DLS/i03_i04_NXmx/hdf5`                 | `Therm_6_2.nxs`                        | HDF5         | 1             | error             |
+| `./DLS/i16/hdf5`                          | `538039.nxs`                           | HDF5         | not NeXus     | -                 |
+| `./DLS/i16/hdf5/538039-pilatus100k-files` | `538039.hdf`                           | HDF5         | 1             | None found        |
+| `./DLS/p45/hdf5`                          | `p45-1168-mic.hdf5`                    | HDF5         | 1             | None found        |
+| `./DLS/p45/hdf5`                          | `p45-1168.nxs`                         | HDF5         | 1             | None found        |
+| `./DLS/p45/hdf5`                          | `p45-2194.nxs`                         | HDF5         | 1             | None found        |
+| `./DLS/p45/hdf5`                          | `p45-316.nxs`                          | HDF5         | 1             | None found        |
+| `./DLS/reflections/hdf5`                  | `thaumatin_integrated.nxs`             | HDF5         | 1             | error             |
+| `./DLS/reflections/hdf5`                  | `thaumatin_integrated_multisample.nxs` | HDF5         | 1             | error             |
+| `./IPNS/LRMECS/hdf4`                      | `lrcs3701.nxs`                         | unrecognised | -             | -                 |
+| `./IPNS/LRMECS/hdf5`                      | `lrcs3701.nx5`                         | HDF5         | 2             | None found        |
+| `./Soleil/hdf5`                           | `file_1.nxs`                           | HDF5         | 1             | error             |
+| `./Soleil/hdf5`                           | `file_2.nxs`                           | HDF5         | 1             | error             |
+| `./SwissFEL`                              | `README`                               | unrecognised | -             | -                 |
+| `./SwissFEL/hdf5`                         | `lyso009a_0087.JF07T32V01_master.h5`   | HDF5         | 1             | error             |
+| `./code/hdf4`                             | `NXtest.hdf`                           | HDF4         | *             | *                 |
+| `./code/hdf4`                             | `dmc01.hdf`                            | HDF4         | *             | *                 |
+| `./code/hdf4`                             | `dmc02.hdf`                            | HDF4         | *             | *                 |
+| `./code/hdf5`                             | `NXtest.h5`                            | HDF5         | 2             | None found        |
+| `./code/hdf5`                             | `dmc01.h5`                             | HDF5         | 1             | None found        |
+| `./code/hdf5`                             | `dmc02.h5`                             | HDF5         | 1             | None found        |
+| `./code/hdf5`                             | `focus2007n001335.hdf`                 | HDF5         | 1             | None found        |
+| `./code/hdf5`                             | `sans2009n012333.hdf`                  | HDF5         | 1             | None found        |
+| `./hdf5`                                  | `simple3D.h5`                          | HDF5         | 1             | None found        |
+| `./hdf5`                                  | `writer_1_3.h5`                        | HDF5         | 1             | None found        |
+| `./hdf5`                                  | `writer_1_3__niac2014.h5`              | HDF5         | 1             | None found        |
+| `./nxpdb`                                 | `4n8z.cif`                             | unrecognised | -             | -                 |
+| `./nxpdb`                                 | `4n8z.h5.cif`                          | unrecognised | -             | -                 |
+| `./nxpdb/hdf5`                            | `4n8z.h5`                              | HDF5         | 1             | None found        |
+| `./xml`                                   | `verysimple.xml`                       | XML          | *             | *                 |
 

--- a/critique.py
+++ b/critique.py
@@ -240,7 +240,7 @@ class Registrar(object):
         table.labels = self.table_labels
         for path, flist in sorted(self.db.items()):
             for fname, critique in sorted(flist.items()):
-                table.addRow(["``"+path+"``","``"+fname+"``"]+ critique.test_results)
+                table.addRow(["`"+path+"`","`"+fname+"`"]+ critique.test_results)
             
         print(table.reST(fmt="markdown"))
 
@@ -279,6 +279,7 @@ def main(path = None):
     print("* date: %s" % datetime.datetime.now())
     print("* h5py version: %s" % h5py.__version__)
     print("* unimplemented test cases are marked in the table with an asterisk")
+    print("")
     registrar.report()
 
 

--- a/critique.py
+++ b/critique.py
@@ -77,47 +77,12 @@ class Critic(object):
         self.filetype = "unrecognised"
         self.test_results = []
 
-        ## can the file be found?
-        #fullname = os.path.join(path, fname)
-        #if not os.path.exists(fullname):
-            #return
-
-        ## Is it really a file?
-        #if not os.path.isfile(fullname):
-            #return
-        
-        ## ok, passes basic qualifications, proceed
-        #self.path = path
-        #self.fname = fname
-
-        #try:
-            #with h5py.File(fullname, mode="r") as root:
-                #self.filetype = "HDF5 file"
-                #self.NXentry_nodes = self.find_NX_class_nodes(root, "NXentry")
-                #if len(self.NXentry_nodes) > 0:
-                    #self.filetype = "NeXus HDF5 file"
-        #except IOError:
-            #pass        # cannot open with HDF5
-
-        # now deeper validation of the NeXus data file
         test_bank = [func for func in dir(Critic) if callable(getattr(Critic, func)) and func.startswith("test_")]
         for t in test_bank:
             try:
                 self.test_results += [getattr(self, t)(path, fname)]
             except:
                 self.test_results += ["error"]
-    
-    def describe_file(self):
-        s = self.filetype
-        if len(self.NXentry_nodes) > 0:
-            s += ', %d **NXentry** group' % len(self.NXentry_nodes)
-            if len(self.NXentry_nodes) > 1:
-                s += 's'
-        return s
-
-    def __str__(self, *args, **kwargs):
-        #print(self.test_results)
-        return self.describe_file() 
     
     def find_NX_class_nodes(self, parent, nx_class = 'NXentry'):
         '''identify the NXentry (or as specified) nodes'''
@@ -133,13 +98,9 @@ class Critic(object):
     def test_01(self, path, fname):
         if path is None and fname is None:
             return "File Type"
-        #self.filetype = "unrecognised"
         try:
             with h5py.File(os.path.join(self.path, self.fname), mode="r") as root:
                 self.filetype = "HDF5"
-                #self.NXentry_nodes = self.find_NX_class_nodes(root, "NXentry")
-                #if len(self.NXentry_nodes) > 0:
-                    #self.filetype = "NeXus HDF5"
         except IOError:
             pass        # cannot open with HDF5
         
@@ -153,7 +114,6 @@ class Critic(object):
         if self.filetype == "unrecognised": # try to ID as HDF4
             MAGIC_HDF4 = b'\x0e\x03\x13\x01\x00\xc8\x00\x00'
             with open(os.path.join(self.path, self.fname), "rb") as file:
-                #file.seek(0)
                 sig = file.read(8)
             if sig == MAGIC_HDF4:
                 self.filetype = "HDF4"

--- a/critique.py
+++ b/critique.py
@@ -39,6 +39,7 @@ import numpy
 import pyRestTable
 import os
 import sys
+import xml.etree.ElementTree as ET
 
 
 def isNeXusGroup(obj, NXtype):
@@ -62,40 +63,49 @@ def isNeXusGroup(obj, NXtype):
 
 class Critic(object):
     '''
-    describe a file in terms of NeXus compliance
+    describe a file in terms of NeXus compliance.
+    Each method starting with "test_" will contribute a column to the results table.
     
+    :param str path: absolute or relative path to the file directory
     :param str fname: (absolute or relative path and) name of file
     '''
     
     def __init__(self, path, fname):
-        self.path = None
-        self.fname = None
-        self.NXentry_nodes = []
-        self.filetype = "not HDF5 file"
-
-        # can the file be found?
-        fullname = os.path.join(path, fname)
-        if not os.path.exists(fullname):
-            return
-
-        # Is it really a file?
-        if not os.path.isfile(fullname):
-            return
-        
-        # ok, passes basic qualifications, proceed
         self.path = path
         self.fname = fname
+        self.NXentry_nodes = []
+        self.filetype = "unrecognised"
+        self.test_results = []
 
-        try:
-            with h5py.File(fullname, mode="r") as root:
-                self.filetype = "HDF5 file"
-                self.NXentry_nodes = self.find_NX_class_nodes(root, "NXentry")
-                if len(self.NXentry_nodes) > 0:
-                    self.filetype = "NeXus HDF5 file"
-        except IOError:
-            pass        # cannot open with HDF5
+        ## can the file be found?
+        #fullname = os.path.join(path, fname)
+        #if not os.path.exists(fullname):
+            #return
 
-        # no deeper validation of the NeXus data file
+        ## Is it really a file?
+        #if not os.path.isfile(fullname):
+            #return
+        
+        ## ok, passes basic qualifications, proceed
+        #self.path = path
+        #self.fname = fname
+
+        #try:
+            #with h5py.File(fullname, mode="r") as root:
+                #self.filetype = "HDF5 file"
+                #self.NXentry_nodes = self.find_NX_class_nodes(root, "NXentry")
+                #if len(self.NXentry_nodes) > 0:
+                    #self.filetype = "NeXus HDF5 file"
+        #except IOError:
+            #pass        # cannot open with HDF5
+
+        # now deeper validation of the NeXus data file
+        test_bank = [func for func in dir(Critic) if callable(getattr(Critic, func)) and func.startswith("test_")]
+        for t in test_bank:
+            try:
+                self.test_results += [getattr(self, t)(path, fname)]
+            except:
+                self.test_results += ["error"]
     
     def describe_file(self):
         s = self.filetype
@@ -106,6 +116,7 @@ class Critic(object):
         return s
 
     def __str__(self, *args, **kwargs):
+        #print(self.test_results)
         return self.describe_file() 
     
     def find_NX_class_nodes(self, parent, nx_class = 'NXentry'):
@@ -115,6 +126,96 @@ class Critic(object):
             if isNeXusGroup(node, nx_class):
                 node_list.append(node)
         return node_list
+    
+### Each method starting with "test_" will contribute a column to the results table.
+### The tests are conducted in alphabetical order.
+### Note that each test can write attributes onto self for later tests to use.
+    def test_01(self, path, fname):
+        if path is None and fname is None:
+            return "File Type"
+        #self.filetype = "unrecognised"
+        try:
+            with h5py.File(os.path.join(self.path, self.fname), mode="r") as root:
+                self.filetype = "HDF5"
+                #self.NXentry_nodes = self.find_NX_class_nodes(root, "NXentry")
+                #if len(self.NXentry_nodes) > 0:
+                    #self.filetype = "NeXus HDF5"
+        except IOError:
+            pass        # cannot open with HDF5
+        
+        if self.filetype == "unrecognised": # try to ID as XML
+            try:
+                tree = ET.parse(os.path.join(self.path, self.fname))
+                self.filetype = "XML"
+            except ET.ParseError:
+                pass        # cannot open as XML
+        
+        if self.filetype == "unrecognised": # try to ID as HDF4
+            MAGIC_HDF4 = b'\x0e\x03\x13\x01\x00\xc8\x00\x00'
+            with open(os.path.join(self.path, self.fname), "rb") as file:
+                #file.seek(0)
+                sig = file.read(8)
+            if sig == MAGIC_HDF4:
+                self.filetype = "HDF4"
+        return self.filetype
+
+#    def test_01a(self, path, fname):
+#        if path is None and fname is None:
+#            return "Header"
+#        with open(os.path.join(self.path, self.fname), "rb") as file:
+#            file.seek(0)
+#            sig = file.read(8)
+#        return ":".join("{:02x}".format(x) for x in bytearray(sig))
+
+    def test_02(self, path, fname):
+        if path is None and fname is None:
+            return "NXentry Count"
+        if self.filetype == "HDF5":
+            with h5py.File(os.path.join(self.path, self.fname), mode="r") as root:
+                NXentry_nodes = self.find_NX_class_nodes(root, "NXentry")
+                self.nNXentry = len(NXentry_nodes)
+            if self.nNXentry == 0:
+                return "not NeXus"
+        elif self.filetype == "XML":
+            self.nNXentry = "*"
+        elif self.filetype == "HDF4":
+            self.nNXentry = "*"
+        else:
+            self.nNXentry = "-"
+        return self.nNXentry
+
+    def test_03(self, path, fname):
+        if path is None and fname is None:
+            return "Application Def's"
+        if self.filetype == "HDF5":
+            if self.nNXentry < 1:
+                AppDefList = "-"
+            else:
+                ad_list = set() # like a list, but only keep unique strings
+                with h5py.File(os.path.join(self.path, self.fname), mode="r") as root:
+                    NXentry_nodes = self.find_NX_class_nodes(root, "NXentry")
+                    for entry in NXentry_nodes:
+                        subentry_list = self.find_NX_class_nodes(entry, "NXsubentry")
+                        if len(subentry_list) == 0:
+                            if 'definition' in list(entry):
+                                ad_list.add(str(entry['definition'][0], encoding='utf-8'))
+                        else:
+                            for sub in subentry_list:
+                                ad_list.add(str(sub['definition'][0], encoding='utf-8'))
+                if len(ad_list) == 0:
+                    AppDefList = "None found"
+                else:
+                    AppDefList = ",".join(ad_list)
+        elif self.filetype == "XML":
+            AppDefList = "*"
+            
+        elif self.filetype == "HDF4":
+            AppDefList = "*"
+            
+        else:
+            AppDefList = "-"
+            
+        return AppDefList
 
 
 class Registrar(object):
@@ -122,6 +223,9 @@ class Registrar(object):
 
     def __init__(self):
         self.db = {}
+        self.test_bank = [func for func in dir(Critic) if callable(getattr(Critic, func)) and func.startswith("test_")]
+        self.table_labels = ["path", "file"] + Critic( None, None).test_results
+
 
     def add(self, path, critic):
         '''add new critique to the database'''
@@ -132,14 +236,13 @@ class Registrar(object):
         self.db[path][critic.fname] = critic
     
     def report(self):
+        table = pyRestTable.Table()
+        table.labels = self.table_labels
         for path, flist in sorted(self.db.items()):
-            table = pyRestTable.Table()
-            table.labels = ["file", "critique"]
             for fname, critique in sorted(flist.items()):
-                table.addRow(("``"+fname+"``", critique))
+                table.addRow(["``"+path+"``","``"+fname+"``"]+ critique.test_results)
             
-            print("\n## path: " + path + "\n")
-            print(table.reST(fmt="markdown"))
+        print(table.reST(fmt="markdown"))
 
 
 def walk_function(registrar, path, files):
@@ -153,13 +256,14 @@ def walk_function(registrar, path, files):
     if path.find('.git') > -1:      # skip the Git VCS directory
         return
     for nm in files:
-        registrar.add(path, Critic(path, nm))
+        if os.path.splitext(nm)[1] not in ['.txt','.py','.rst','.md','.in'] and nm[0] != '.': # skip other types of file
+                registrar.add(path, Critic(path, nm))
 
 
 def main(path = None):
     '''traverse a directory and describe how each file conforms to NeXus'''
     registrar = Registrar()
-    paths = [path or os.path.dirname(__file__)]
+    paths = [path or os.path.dirname(__file__) or '.']
     while len(paths) > 0:
         path = paths.pop()
         for subdir, dir_list, file_list in os.walk(path):
@@ -174,6 +278,7 @@ def main(path = None):
     print("")
     print("* date: %s" % datetime.datetime.now())
     print("* h5py version: %s" % h5py.__version__)
+    print("* unimplemented test cases are marked in the table with an asterisk")
     registrar.report()
 
 


### PR DESCRIPTION
Fixes #20 
Performing tests on the example files is now modular and each test reports with its own column. Tests are implemented to:
- identify the container files (HDF5, HDF4 and XML),
- count the NXentry groups (only implemented for HDF5 so far), and
- show the names of any application definitions included (only implemented for HDF5 so far)

Implementing the tests for XML should be straightforward, but I don't think the HDF4 dependencies are worth working with.